### PR TITLE
set `ignore.case=TRUE` in order to also parse files ending with lower…

### DIFF
--- a/R/get_dependent_packages.R
+++ b/R/get_dependent_packages.R
@@ -9,7 +9,7 @@
 #' @export
 get_dependent_packages <- function(directory = getwd()) {
   fls <- list.files(path=directory,pattern='^.*\\.R$|^.*\\.Rmd$',
-                    full.names=TRUE,recursive=TRUE)
+                    full.names=TRUE,recursive=TRUE,ignore.case=TRUE)
   pkg_names <- unlist(sapply(fls,parse_packages))
   pkg_names <- unique(pkg_names)
   if (length(pkg_names)==0) {


### PR DESCRIPTION
…case ".r", ".rmd", etc.

Thanks for this package!  This PR fixes an issues where `get_dependent_packages()` does not list files ending in lowercase ".r" and ".rmd" for parsing by `parse_packages()`.  

I ran into this bug today when trying to determine the package deps for a Shiny app.  The dev was using ".r" extensions on some of their files.

I tested locally after applying this change and the fix worked.  I didn't see any tests for this function, but let me know if you'd like for me to include one with this PR.