### PR TITLE
Update get_dependent_packages.R

### DIFF
--- a/R/get_dependent_packages.R
+++ b/R/get_dependent_packages.R
@@ -10,6 +10,7 @@
 get_dependent_packages <- function(directory = getwd()) {
   fls <- list.files(path=directory,pattern='^.*\\.R$|^.*\\.Rmd$',
                     full.names=TRUE,recursive=TRUE,ignore.case=TRUE)
+  fls <- fls[!grepl("renv", fls)]
   pkg_names <- unlist(sapply(fls,parse_packages))
   pkg_names <- unique(pkg_names)
   if (length(pkg_names)==0) {


### PR DESCRIPTION
I am using `renv` together with this package. `automagic` gives error in searching dependencies when `renv` folder is present. That is why I have added
`fls <- fls[!grepl("renv", fls)]` this line to exclue `renv` folder as a suggestion.